### PR TITLE
Tournament: Minor UI + functionality changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "immutable": "^3.8.1",
+    "jsplumb": "^2.4.2",
     "prop-types": "^15.5.10",
     "rc-slider": "^7.0.8",
     "react": "^15.5.4",
@@ -43,7 +44,8 @@
     "semantic-ui-css": "^2.2.10",
     "semantic-ui-react": "^0.68.4",
     "socket.io-client": "^2.0.1",
-    "ultimate-ttt": "^4.5.0"
+    "ultimate-ttt": "^4.5.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "gh-pages": "^1.0.0",

--- a/src/components/SocketProvider/index.js
+++ b/src/components/SocketProvider/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import io from 'socket.io-client';
 
-class Socket extends React.Component {
+class SocketProvider extends React.Component {
   constructor(props) {
     super(props);
 
@@ -47,7 +47,7 @@ class Socket extends React.Component {
       this.props.actions.updateStats(data);
     });
 
-    this.socket.on('tournaments', (data) => {
+    this.socket.on('tournament', (data) => {
       this.props.actions.updateTournaments(data);
     });
 
@@ -85,14 +85,42 @@ class Socket extends React.Component {
     });
 
     this.socket.connect();
+
+    setTimeout(() => {
+      let urlParams = {};
+      (window.onpopstate = function () {
+        let match,
+          pl     = /\+/g,  // Regex for replacing addition symbol with a space
+          search = /([^&=]+)=?([^&]*)/g,
+          decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
+          query  = window.location.search.substring(1);
+
+        urlParams = {};
+        while (match = search.exec(query))
+          urlParams[decode(match[1])] = decode(match[2]);
+      })();
+      if (urlParams.startTournament) {
+        console.log('Starting tournament');
+        this.socket.emit('tournament', { start: true });
+      }
+    }, 100);
   };
 
-  render (){ return null; }
+  render() {
+    return (
+      <div>
+        { this.props.children }
+      </div>
+    );
+  }
 }
 
+SocketProvider.childContextTypes = {
+  socket: PropTypes.object,
+};
 
-Socket.propTypes = {
-host: PropTypes.string.isRequired,
+SocketProvider.propTypes = {
+  host: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   actions: PropTypes.shape({
     connected: PropTypes.func.isRequired,
@@ -103,4 +131,4 @@ host: PropTypes.string.isRequired,
   }).isRequired,
 };
 
-export default Socket;
+export default SocketProvider;

--- a/src/components/TournamentGame/Connection/index.css
+++ b/src/components/TournamentGame/Connection/index.css
@@ -1,0 +1,32 @@
+.jtk-endpoint, .jtk-endpoint circle {
+    fill: none;
+    stroke: none;
+}
+
+.jtk-connector {
+    fill: #aaa;
+    stroke: #aaa;
+}
+
+.jtk-connector.active {
+    fill: #4183C4;
+    stroke: #4183C4;
+}
+
+.jtk-connector path {
+    stroke: inherit;
+    fill: inherit;
+}
+
+path.jtk-connector-outline {
+    stroke: transparent;
+}
+
+.jtk-hover {
+    stroke: #1e70bf;
+    fill: #1e70bf;
+}
+
+.jtk-dragged {
+    cursor: move;
+}

--- a/src/components/TournamentGame/Connection/index.js
+++ b/src/components/TournamentGame/Connection/index.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './index.css';
+
+export default class Connection extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+  componentDidMount() {
+    setTimeout(() => {
+      this.connection = this.props.jsPlumbInstance.connect({
+        source: this.props.sourceId,
+        target: this.props.targetId,
+        anchors:["Right", "Left" ],
+        endpoint: 'Blank',
+        paintStyle: {
+          strokeWidth: 2,
+          outlineStroke: 'transparent',
+          outlineWidth: 10,
+        },
+        label: null,
+      });
+    }, 100);
+  }
+
+  componentDidUpdate() {
+    if (!this.props.winner) {
+      this.connection.removeClass('winner');
+    } else {
+      this.connection.addClass('winner');
+    }
+  }
+
+  componentWillUnmount() {
+    try {
+      this.props.jsPlumbInstance.detach(this.connection);
+    } catch (ignored) {
+      // this will typically throw an exception, as the tier is removed before
+      // which removes all connections
+    }
+  }
+
+  render() { return null; }
+}
+
+// PropTypes
+Connection.propTypes = {
+  sourceId: PropTypes.string.isRequired,
+  targetId: PropTypes.string.isRequired,
+  winner: PropTypes.bool.isRequired,
+  jsPlumbInstance: PropTypes.object.isRequired,
+};

--- a/src/components/TournamentGame/Player/index.js
+++ b/src/components/TournamentGame/Player/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Loader } from 'semantic-ui-react';
+
+export default class Player extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+  componentDidMount() {
+    this.addConnectors();
+  }
+
+  addConnectors = () => {
+    if (!this.props.name) {
+      return;
+    }
+
+    const sourceConfig = {
+      anchor: 'Continuous',
+      endpoint: 'Blank',
+      isSource: false,
+      connector: ['Flowchart'],
+      maxConnections: 10,
+      isTarget: false,
+      dropOptions: {
+        tolerance: 'touch',
+        hoverClass: 'dropHover',
+        activeClass: 'dropActive',
+      },
+    };
+
+    const targetConfig = {
+      dropOptions: {
+        hoverClass: 'dropHover',
+      },
+      endpoint: 'Blank',
+      anchor: 'Continuous',
+      isTarget: false,
+    };
+
+    this.props.jsPlumbInstance.makeSource(this.playerEl, sourceConfig);
+    this.props.jsPlumbInstance.makeTarget(this.playerEl, targetConfig);
+  };
+
+  render() {
+    if (!this.props.name) {
+      return null;
+    }
+
+    return (
+      <div
+        ref={ (ref) => { this.playerEl = ref; } }
+        style={ this.props.style }
+        id={ this.props.id }
+        className={
+          classNames('game', 'game-top', { won: this.props.winner })
+        }
+      >
+        {this.props.name}
+        <span>
+            <Loader inline size='mini' active={ this.props.isPlaying } />
+          </span>
+      </div>
+    );
+  }
+}
+
+// PropTypes
+Player.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  winner: PropTypes.bool.isRequired,
+  jsPlumbInstance: PropTypes.object.isRequired,
+  style: PropTypes.object.isRequired,
+};

--- a/src/components/TournamentGame/Player/index.js
+++ b/src/components/TournamentGame/Player/index.js
@@ -66,7 +66,7 @@ export default class Player extends React.PureComponent { // eslint-disable-line
 // PropTypes
 Player.propTypes = {
   id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   winner: PropTypes.bool.isRequired,
   jsPlumbInstance: PropTypes.object.isRequired,
   style: PropTypes.object.isRequired,

--- a/src/components/TournamentGame/index.css
+++ b/src/components/TournamentGame/index.css
@@ -1,0 +1,31 @@
+.round > div {
+    flex-grow: 1;
+}
+
+.game span {
+    float:right;
+    margin-right:5px;
+}
+
+.winner {
+    font-weight:bold;
+}
+
+.game span {
+    float:right;
+    margin-right:5px;
+}
+
+.game-pair {
+    margin-bottom: 20px;
+}
+
+.game {
+    background: #efefef;
+    margin-bottom: 20px;
+    padding: 5px 10px;
+}
+
+.winner {
+    font-weight:bold;
+}

--- a/src/components/TournamentGame/index.css
+++ b/src/components/TournamentGame/index.css
@@ -1,14 +1,6 @@
-.round > div {
-    flex-grow: 1;
-}
-
 .game span {
     float:right;
     margin-right:5px;
-}
-
-.winner {
-    font-weight:bold;
 }
 
 .game span {
@@ -24,8 +16,10 @@
     background: #efefef;
     margin-bottom: 20px;
     padding: 5px 10px;
+    border-left: 5px solid #ccc;
 }
 
-.winner {
+.game.won {
     font-weight:bold;
+    border-left-color: #21BA45;
 }

--- a/src/components/TournamentGame/index.js
+++ b/src/components/TournamentGame/index.js
@@ -1,78 +1,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 import './index.css';
 import Connection from './Connection/index';
+import Player from './Player/index';
 
 class TournamentGame extends React.Component {
-
-  componentDidMount() {
-    this.addConnectors();
-  }
-
   getId = (round, game, player) => `R${round}-G${game}-P${player}`;
-
-  addConnectors = () => {
-
-    const sourceConfig = {
-      anchor: 'Continuous',
-      endpoint: 'Blank',
-      isSource: false,
-      connector: ['Flowchart'],
-      maxConnections: 10,
-      isTarget: false,
-      dropOptions: {
-        tolerance: 'touch',
-        hoverClass: 'dropHover',
-        activeClass: 'dropActive',
-      },
-    };
-
-    const targetConfig = {
-      dropOptions: {
-        hoverClass: 'dropHover',
-      },
-      endpoint: 'Blank',
-      anchor: 'Continuous',
-      isTarget: false,
-    };
-
-    this.props.jsPlumbInstance.makeSource(this.gameA, sourceConfig);
-    this.props.jsPlumbInstance.makeTarget(this.gameA, targetConfig);
-
-    this.props.jsPlumbInstance.makeSource(this.gameB, sourceConfig);
-    this.props.jsPlumbInstance.makeTarget(this.gameB, targetConfig);
-    this.props.jsPlumbInstance.addEndpoint(this.gameA, {
-
-    });
-  };
 
   render() {
     const nextRound = this.props.roundIndex + 1;
     const nextGame = Math.floor(this.props.gameIndex / 2);
     const nextPlayer = (Math.round(this.props.gameIndex / 2) === nextGame) ? 0 : 1;
 
+    let gameMargin = 0;
+    let playerAMarginTop = 0;
+    let playerBMarginTop = 0;
+    if (this.props.roundIndex > 0) {
+      gameMargin = Math.pow(this.props.roundIndex, 2) * 15;
+      playerAMarginTop = this.props.roundIndex * 10;
+      playerBMarginTop = this.props.roundIndex * 73;
+    }
+
     return (
-      <div className='game-pair'>
-        <div
-          ref={ (ref) => { this.gameA = ref; } }
+      <div className='game-pair' style={ { marginTop: gameMargin, marginBottom: gameMargin } }>
+        <Player
           id={ this.getId(this.props.roundIndex, this.props.gameIndex, 0) }
-          className={
-            classNames('game', 'game-top', {winner: this.props.game.playerA === this.props.game.winner })
-          }
-        >
-          {this.props.game.playerA}
-        </div>
-        <div
-          ref={ (ref) => { this.gameB = ref; } }
+          style={ { marginTop: playerAMarginTop } }
+          winner={ this.props.game.playerA === this.props.game.winner }
+          name={ this.props.game.playerA }
+          jsPlumbInstance={ this.props.jsPlumbInstance }
+        />
+        <Player
           id={ this.getId(this.props.roundIndex, this.props.gameIndex, 1) }
-          className={
-            classNames('game', 'game-bottom', {winner: this.props.game.playerB === this.props.game.winner })
-          }
-        >
-          {this.props.game.playerB}
-        </div>
+          style={ { marginTop: playerBMarginTop } }
+          winner={ this.props.game.playerB === this.props.game.winner }
+          name={ this.props.game.playerB }
+          jsPlumbInstance={ this.props.jsPlumbInstance }
+        />
         <Connection
           jsPlumbInstance={ this.props.jsPlumbInstance }
           sourceId={ this.getId(this.props.roundIndex, this.props.gameIndex, 0) }
@@ -93,6 +58,7 @@ class TournamentGame extends React.Component {
 TournamentGame.PropTypes = {
   game: PropTypes.object.isRequired,
   gameIndex: PropTypes.number.isRequired,
+  isPlaying: PropTypes.bool.isRequired,
   roundIndex: PropTypes.number.isRequired,
   jsPlumbInstance: PropTypes.object.isRequired,
 };

--- a/src/components/TournamentGame/index.js
+++ b/src/components/TournamentGame/index.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import './index.css';
+import Connection from './Connection/index';
+
+class TournamentGame extends React.Component {
+
+  componentDidMount() {
+    this.addConnectors();
+  }
+
+  getId = (round, game, player) => `R${round}-G${game}-P${player}`;
+
+  addConnectors = () => {
+
+    const sourceConfig = {
+      anchor: 'Continuous',
+      endpoint: 'Blank',
+      isSource: false,
+      connector: ['Flowchart'],
+      maxConnections: 10,
+      isTarget: false,
+      dropOptions: {
+        tolerance: 'touch',
+        hoverClass: 'dropHover',
+        activeClass: 'dropActive',
+      },
+    };
+
+    const targetConfig = {
+      dropOptions: {
+        hoverClass: 'dropHover',
+      },
+      endpoint: 'Blank',
+      anchor: 'Continuous',
+      isTarget: false,
+    };
+
+    this.props.jsPlumbInstance.makeSource(this.gameA, sourceConfig);
+    this.props.jsPlumbInstance.makeTarget(this.gameA, targetConfig);
+
+    this.props.jsPlumbInstance.makeSource(this.gameB, sourceConfig);
+    this.props.jsPlumbInstance.makeTarget(this.gameB, targetConfig);
+    this.props.jsPlumbInstance.addEndpoint(this.gameA, {
+
+    });
+  };
+
+  render() {
+    const nextRound = this.props.roundIndex + 1;
+    const nextGame = Math.floor(this.props.gameIndex / 2);
+    const nextPlayer = (Math.round(this.props.gameIndex / 2) === nextGame) ? 0 : 1;
+
+    return (
+      <div className='game-pair'>
+        <div
+          ref={ (ref) => { this.gameA = ref; } }
+          id={ this.getId(this.props.roundIndex, this.props.gameIndex, 0) }
+          className={
+            classNames('game', 'game-top', {winner: this.props.game.playerA === this.props.game.winner })
+          }
+        >
+          {this.props.game.playerA}
+        </div>
+        <div
+          ref={ (ref) => { this.gameB = ref; } }
+          id={ this.getId(this.props.roundIndex, this.props.gameIndex, 1) }
+          className={
+            classNames('game', 'game-bottom', {winner: this.props.game.playerB === this.props.game.winner })
+          }
+        >
+          {this.props.game.playerB}
+        </div>
+        <Connection
+          jsPlumbInstance={ this.props.jsPlumbInstance }
+          sourceId={ this.getId(this.props.roundIndex, this.props.gameIndex, 0) }
+          targetId={ this.getId(nextRound, nextGame, nextPlayer) }
+          winner={ this.props.game.playerA === this.props.game.winner }
+        />
+        <Connection
+          jsPlumbInstance={ this.props.jsPlumbInstance }
+          sourceId={ this.getId(this.props.roundIndex, this.props.gameIndex, 1) }
+          targetId={ this.getId(nextRound, nextGame, nextPlayer) }
+          winner={ this.props.game.playerB === this.props.game.winner }
+        />
+      </div>
+    );
+  }
+}
+
+TournamentGame.PropTypes = {
+  game: PropTypes.object.isRequired,
+  gameIndex: PropTypes.number.isRequired,
+  roundIndex: PropTypes.number.isRequired,
+  jsPlumbInstance: PropTypes.object.isRequired,
+};
+
+export default TournamentGame;

--- a/src/containers/SocketContainer/index.js
+++ b/src/containers/SocketContainer/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import Socket from '../../components/Socket';
+import SocketProvider from '../../components/SocketProvider';
 
 import { getState } from '../ServerContainer/selectors';
 import * as serverActions from '../ServerContainer/actions';
@@ -16,4 +16,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Socket);
+export default connect(mapStateToProps, mapDispatchToProps)(SocketProvider);

--- a/src/containers/TournamentContainer/index.js
+++ b/src/containers/TournamentContainer/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import Server from '../../sections/Tournaments';
+import Tournaments from '../../sections/Tournaments';
 
 import { getState } from './selectors';
 import * as actions from './actions';
@@ -14,4 +14,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Server);
+export default connect(mapStateToProps, mapDispatchToProps)(Tournaments);

--- a/src/containers/TournamentContainer/reducer.js
+++ b/src/containers/TournamentContainer/reducer.js
@@ -81,7 +81,8 @@ const round4 = {
 };
 
 const tournament = {
-  rounds: [round1, round2, round3, round4]
+  rounds: [round1, round2, round3, round4],
+  started: false,
 };
 
 export const initialState = Map(tournament);

--- a/src/containers/TournamentContainer/reducer.js
+++ b/src/containers/TournamentContainer/reducer.js
@@ -57,6 +57,13 @@ const round3Game1 = {
   result: gameStatuses.IN_PROGRESS
 };
 
+const round4Game1 = {
+  playerA: "player2",
+  playerB: null,
+  winner: null,
+  result: gameStatuses.IN_PROGRESS
+};
+
 const round1 = {
   games: [round1Game1, round1Game2, round1Game3, round1Game4]
 };
@@ -69,8 +76,12 @@ const round3 = {
   games: [round3Game1]
 };
 
+const round4 = {
+  games: [round4Game1]
+};
+
 const tournament = {
-  rounds: [round1, round2, round3]
+  rounds: [round1, round2, round3, round4]
 };
 
 export const initialState = Map(tournament);

--- a/src/sections/App/index.js
+++ b/src/sections/App/index.js
@@ -2,20 +2,19 @@ import React from 'react';
 import { Container } from 'semantic-ui-react';
 
 import Header from '../../components/Header';
-import Socket from '../../containers/SocketContainer';
+import SocketContainer from '../../containers/SocketContainer';
 
 import './index.css';
 
 class App extends React.Component {
   render() {
     return (
-      <div>
+      <SocketContainer>
         <Header />
-        <Socket />
         <Container>
           { this.props.children }
         </Container>
-      </div>
+      </SocketContainer>
     );
   }
 }

--- a/src/sections/Tournaments/index.css
+++ b/src/sections/Tournaments/index.css
@@ -1,45 +1,18 @@
-main, ul {
+main, .round {
     display:flex;
 }
 
-ul {
+.round {
     flex-direction:column;
     width: 200px;
     list-style:none;
     padding:0;
+    margin-right: 50px;
 }
 
-.game + li {
-    flex-grow:1;
-}
-
-ul:before, ul:after {
+.round:before,
+.round:after {
     content: " ";
     display: inline-block;
     flex-grow:.5;
-}
-
-.game {
-    padding-left:20px;
-}
-
-.winner {
-    font-weight:bold;
-}
-
-.game span {
-    float:right;
-    margin-right:5px;
-}
-
-.game-top {
-    border-bottom:1px solid #aaa;
-}
-
-.game-top + li {
-    border-right:1px solid #aaa; min-height:40px;
-}
-
-.game-bottom {
-    border-top:1px solid #aaa;
 }

--- a/src/sections/Tournaments/index.css
+++ b/src/sections/Tournaments/index.css
@@ -9,10 +9,3 @@ main, .round {
     padding:0;
     margin-right: 50px;
 }
-
-.round:before,
-.round:after {
-    content: " ";
-    display: inline-block;
-    flex-grow:.5;
-}

--- a/src/sections/Tournaments/index.js
+++ b/src/sections/Tournaments/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import jsplumb from 'jsplumb';
+import { Segment } from 'semantic-ui-react';
+
 import './index.css';
 
 import TournamentGame from '../../components/TournamentGame/index';
@@ -9,8 +11,8 @@ class Tournaments extends React.Component {
   /**
    * Prepare a jsPlumb instance
    */
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     const jsPlumb = (jsplumb.jsPlumb) ? jsplumb.jsPlumb : jsplumb;
     this.jsPlumbInstance = jsPlumb.getInstance({
       Container: this.canvas,
@@ -43,35 +45,51 @@ class Tournaments extends React.Component {
     });
   };
 
+  getParameterByName = (name, url) => {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    const regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+      results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+  };
+
   render() {
+    const header = (this.props.started) ? 'Tournament' : 'Waiting for Tournament to start...';
     return (
-        <main id="tournament">
-          {
-            this.props.rounds.map((round, $roundIndex) => (
-              <div className={ `round round-${$roundIndex + 1}` } key={ `round-${$roundIndex}` }>
-                {
-                  round.games.map((game, $gameIndex) => (
-                    <TournamentGame
-                      game={ game }
-                      isPlaying={ false }
-                      gameIndex={ $gameIndex }
-                      roundIndex={ $roundIndex }
-                      key={ `game-${$gameIndex}` }
-                      jsPlumbInstance={ this.jsPlumbInstance }
-                    />
-                  ))
-                }
-              </div>
-            ))
-          }
-        </main>
+      <div>
+        <h1>{ header }</h1>
+        <Segment loading={ !this.props.started }>
+          <main id="tournament">
+            {
+              this.props.rounds.map((round, $roundIndex) => (
+                <div className={ `round round-${$roundIndex + 1}` } key={ `round-${$roundIndex}` }>
+                  {
+                    round.games.map((game, $gameIndex) => (
+                      <TournamentGame
+                        game={ game }
+                        isPlaying={ false }
+                        gameIndex={ $gameIndex }
+                        roundIndex={ $roundIndex }
+                        key={ `game-${$gameIndex}` }
+                        jsPlumbInstance={ this.jsPlumbInstance }
+                      />
+                    ))
+                  }
+                </div>
+              ))
+            }
+          </main>
+        </Segment>
+      </div>
     );
   }
 }
 
-
 Tournaments.propTypes = {
   rounds: PropTypes.array.isRequired,
+  started: PropTypes.bool.isRequired,
 };
 
 export default Tournaments;

--- a/src/sections/Tournaments/index.js
+++ b/src/sections/Tournaments/index.js
@@ -1,28 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import jsplumb from 'jsplumb';
 import './index.css';
 
-
-const gameLayout = (game, index) => ([
-  <li key={index * 10 + 1}>&nbsp;</li>,
-  <li className={"game game-top " + (game.playerA === game.winner ? "winner" : "")} key={index * 10 + 2}>{game.playerA}</li>,
-  <li key={index * 10 + 3}>&nbsp;</li>,
-  <li className={"game game-bottom " + (game.playerB === game.winner ? "winner" : "")} key={index * 10 + 4}>{game.playerB}</li>,
-]);
+import TournamentGame from '../../components/TournamentGame/index';
 
 class Tournaments extends React.Component {
+  /**
+   * Prepare a jsPlumb instance
+   */
+  constructor() {
+    super();
+    const jsPlumb = (jsplumb.jsPlumb) ? jsplumb.jsPlumb : jsplumb;
+    this.jsPlumbInstance = jsPlumb.getInstance({
+      Container: this.canvas,
+      ConnectionsDetachable: false,
+      ConnectionOverlays: [
+        ['Arrow', {
+          location: 1,
+          width: 8,
+          length: 6,
+          foldback: 1,
+        }],
+        ['Label', {
+          location: 0.1,
+          id: 'label',
+          cssClass: 'aLabel',
+        }],
+      ],
+    });
+
+    this.jsPlumbInstance.importDefaults({
+      PaintStyle: {
+        strokeWidth: 2,
+        stroke: 'rgb(184, 184, 184)',
+      },
+    });
+
+    this.jsPlumbInstance.registerConnectionType('basic', {
+      connector: ['StateMachine', { gap: 0 }],
+      overlays: ['Arrow'],
+    });
+  };
+
   render() {
     return (
         <main id="tournament">
           {
-            this.props.rounds.map((round, $index) => (
-              <ul className={ `round round-${$index + 1}` }>
+            this.props.rounds.map((round, $roundIndex) => (
+              <div className={ `round round-${$roundIndex + 1}` } key={ `round-${$roundIndex}` }>
                 {
-                  round.games.map((game, index) => (
-                    gameLayout(game, index)
+                  round.games.map((game, $gameIndex) => (
+                    <TournamentGame
+                      game={ game }
+                      gameIndex={ $gameIndex }
+                      roundIndex={ $roundIndex }
+                      key={ `game-${$gameIndex}` }
+                      jsPlumbInstance={ this.jsPlumbInstance }
+                    />
                   ))
                 }
-              </ul>
+              </div>
             ))
           }
         </main>

--- a/src/sections/Tournaments/index.js
+++ b/src/sections/Tournaments/index.js
@@ -53,6 +53,7 @@ class Tournaments extends React.Component {
                   round.games.map((game, $gameIndex) => (
                     <TournamentGame
                       game={ game }
+                      isPlaying={ false }
                       gameIndex={ $gameIndex }
                       roundIndex={ $roundIndex }
                       key={ `game-${$gameIndex}` }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,6 +3756,10 @@ jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
+jsplumb@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/jsplumb/-/jsplumb-2.4.2.tgz#c835b421e90cb310b214e6c6ed22c7100158c1c0"
+
 jsprim@^1.2.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
@@ -6333,7 +6337,7 @@ uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
I've slightly redesigned the tournament page, I decided to go with a library called jsPlumb to render arrows between players + used some Semantic UI components, nothing too fancy.

The server is sending status updates, but I'm getting an error on the server when running in tournament mode - I need to check with @AlexMillward on that. The server sends back an array of "profiles" - we need to find a good way of converting those into something similar to the state in the web client to render the tournament UI.

You can see what they look like in https://github.com/socialgorithm/ultimate-ttt-server/blob/master/src/lib/Tournament.ts#L8

